### PR TITLE
agp 8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ scripts:
 
 ```kotlin
 plugins {
-	id("ch.ubique.gradle.preset") version "8.7.0"
+	id("ch.ubique.gradle.preset") version "8.9.0"
 }
 ```
 

--- a/appexample/build.gradle.kts
+++ b/appexample/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 
 android {
 	namespace = "ch.ubique.preset.example"
-	compileSdk = 34
+	compileSdk = 35
 
 	defaultConfig {
 		applicationId = "ch.ubique.preset.example"
 		minSdk = 26
-		targetSdk = 34
+		targetSdk = 35
 		versionCode = 1
 		versionName = project.version.toString()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-agp = "8.8.0"
+agp = "8.9.0"
 kotlin = "2.1.10"
 pluginPublish = "1.2.2"
 vanniktech = "0.29.0"
 
 androidx-appcompat = "1.7.0"
-androidx-lifecycle = "2.8.6"
+androidx-lifecycle = "2.8.7"
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/libexample/build.gradle.kts
+++ b/libexample/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace = "ch.ubique.preset.example"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/preset/gradle/wrapper/gradle-wrapper.properties
+++ b/preset/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This pull request includes several updates to the Gradle configurations and dependencies across multiple files in the project. The most important changes include updating the Gradle plugin version, the Android Gradle Plugin (AGP) version, and the compile and target SDK versions.

Updates to Gradle and dependencies:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35): Updated the Gradle plugin version from `8.7.0` to `8.9.0`.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL2-R8): Updated AGP version from `8.8.0` to `8.9.0` and `androidx-lifecycle` version from `2.8.6` to `2.8.7`.
* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3): Updated the Gradle distribution URL from `gradle-8.10.2-all.zip` to `gradle-8.11.1-all.zip`. [[1]](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3) [[2]](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3)

Updates to Android SDK versions:

* [`appexample/build.gradle.kts`](diffhunk://#diff-1d806c1bfcb99a74256a2a9b64c2bb336a9e693093f5a45ff4c73a3d466cd50dL12-R17): Updated `compileSdk` and `targetSdk` versions from `34` to `35`.
* [`libexample/build.gradle.kts`](diffhunk://#diff-94c760a63cb57b28924822ffaa82db2e88b92759c3e07938727464060198fae7L9-R13): Updated `compileSdk` and `targetSdk` versions from `34` to `35`.